### PR TITLE
Fixes for frontend Interface

### DIFF
--- a/frontend-client/src/App.vue
+++ b/frontend-client/src/App.vue
@@ -29,7 +29,7 @@ export default {
   --main-cyan-color: #0FF;
   --main-magenta-color: #F0F;
   
-  font-family:  Helvetica, Arial, sans-serif;
+  font-family:   'DejaVu Sans Mono', monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;

--- a/frontend-client/src/components/Body.vue
+++ b/frontend-client/src/components/Body.vue
@@ -27,7 +27,7 @@
     </div>
 
     <div class="">
-      <BodyRefboxLog />
+      <BodyRefboxLog class="border-bottom-0"/>
     </div>
     
   </div>

--- a/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
+++ b/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
@@ -10,7 +10,7 @@
             <div class="base-image-container mr-1">
                     <figure>
                       <div class="station-specific-info-container text-center"
-                           :class="setMachineClass(machine)" 
+                           :class="setMachineBackground(machine)" 
                       >
                         <span class="text-secondary text-center">{{machine.name}}</span>
                       </div>
@@ -20,28 +20,29 @@
                       </figcaption>
                     </figure>
             </div>
-            <div class="machine-info d-flex flex-column">
+            <div class="machine-info d-flex flex-column ">
                   <span :class="setStateClass(machine.state)">
                     {{machine.state}}
                   </span>
+                  <!-- If RS show additional Infi -->
                   <div v-if="machine.mtype === 'RS'" class="d-flex my-1">
                     <span>{{machine['bases-added'] - machine['bases-used']}}</span>
                     <div class="ml-2 d-flex">
                       <div 
                         class="rs-color-container mr-1"
-                        :class="setRsColor(machine['rs-ring-colors'][0])">
+                        :class="setRSandBSColor(machine['rs-ring-colors'][0])">
                         <span class="invisible">color</span>
                       </div>
                       <span>{{showPreparedColorInfo(machine['rs-ring-colors'][0])}}</span>
                       <div 
                         class="rs-color-container mx-1"
-                        :class="setRsColor(machine['rs-ring-colors'][1])">
+                        :class="setRSandBSColor(machine['rs-ring-colors'][1])">
                         <span class="invisible">color</span>
                       </div>
                       <span>{{showPreparedColorInfo(machine['rs-ring-colors'][1])}}</span>
                     </div>
                   </div>
-                  <span>{{machine.name}}</span>
+                  <!-- <span>{{machine.name}}</span> -->
             </div>
           </div>
         </div>
@@ -105,22 +106,31 @@ export default {
       });
       return `- ${reqBases}`;
     },
-    // Sets background color depending on the ringcolor
-    setRsColor(ringcolor) {
-      if (ringcolor === 'RING_BLUE') {
-        return 'bg-info'
-      } else if (ringcolor === 'RING_ORANGE') {
-        return 'bg-primary'
-      } else if (ringcolor === 'RING_GREEN') {
-        return 'bg-success'
-      } else if (ringcolor === 'RING_YELLOW') {
+    // Sets background color depending on the ringcolor and BS-Color
+    setRSandBSColor(color) {
+      if (color === 'RING_BLUE') {
+        return 'bg-blue'
+      } else if (color === 'RING_ORANGE') {
+        return 'bg-orange'
+      } else if (color === 'RING_GREEN') {
+        return 'bg-green'
+      } else if (color === 'RING_YELLOW') {
         return 'bg-yellow'
+      } else if (color === 'BASE_SILVER') {
+        return 'bg-silver'
+      }else if (color === 'BASE_RED') {
+        return 'bg-red'
+      }else if (color === 'BASE_BLACK') {
+        return 'bg-black'
       }
     },
-    setMachineClass(machine){
+    setMachineBackground(machine){
       if(machine.mtype === 'RS'){
-        return this.setRsColor(machine['rs-ring-color'])
+        return this.setRSandBSColor(machine['rs-ring-color'])
+      } else if(machine.mtype === 'BS'){        
+        return this.setRSandBSColor(machine['bs-color'])
       }
+
     }
   }
 }
@@ -147,8 +157,26 @@ figcaption {
   line-height: 1 !important;
 }
 
+.bg-black{
+  background-color: black !important;
+}
+.bg-red{
+  background-color: rgb(228, 44, 44) !important;
+}
+.bg-orange{
+  background-color: orangered !important;
+}
+.bg-green{
+  background-color: green;
+}
+.bg-blue{
+  background-color: blue !important;
+}
 .bg-yellow {
   background-color: yellow !important;
+}
+.bg-silver{
+  background-color: silver !important;
 }
 
 .rs-color-container {

--- a/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
+++ b/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
@@ -70,8 +70,8 @@ export default {
   // Run on mount of Component
   mounted() {
     this.fetchMachinesCyan()
-    this.fetchRingSpec()
-    this.pollMachineInfo();
+    // this.fetchRingSpec()
+    // this.pollMachineInfo();
   },
 
   methods: {

--- a/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
+++ b/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
@@ -12,7 +12,7 @@
                       <div class="station-specific-info-container text-center"
                            :class="setMachineBackground(machine)" 
                       >
-                        <span class="text-secondary text-center">{{machine.name}}</span>
+                        <span class="text-active text-center">{{machine.name}}</span>
                       </div>
                       <figcaption class="text-center machine-zone">{{machine.zone}}
                         <br>

--- a/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
+++ b/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
@@ -12,7 +12,7 @@
                       <div class="station-specific-info-container text-center"
                            :class="setMachineBackground(machine)" 
                       >
-                        <span class="text-active text-center">{{machine.name}}</span>
+                        <span class="text-active font-weight-bold text-center">{{machine.name}}</span>
                       </div>
                       <figcaption class="text-center machine-zone">{{machine.zone}}
                         <br>
@@ -170,10 +170,10 @@ figcaption {
   background-color: green;
 }
 .bg-blue{
-  background-color: blue !important;
+  background-color: rgba(0, 0, 255, 0.651) !important;
 }
 .bg-yellow {
-  background-color: yellow !important;
+  background-color: rgba(255, 255, 0, 0.685) !important;
 }
 .bg-silver{
   background-color: silver !important;

--- a/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
+++ b/frontend-client/src/components/BodyMachinesTeamCyanGenerator.vue
@@ -70,8 +70,8 @@ export default {
   // Run on mount of Component
   mounted() {
     this.fetchMachinesCyan()
-    // this.fetchRingSpec()
-    // this.pollMachineInfo();
+    this.fetchRingSpec()
+    this.pollMachineInfo();
   },
 
   methods: {

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -67,7 +67,7 @@ export default {
 
     setClassName(msgLevel) {
       if (msgLevel === 'info') {
-        return 'text-light'
+        return 'text-active'
       } else if (msgLevel === 'warn' ) {
         return 'text-danger'
       } else if (msgLevel === 'error') {

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -10,7 +10,9 @@
     
     <div class="mx-3 mt-3">
       <div v-for="(msg,index) in msgArray" :key=index>
-        <h6 class= "mb-0" :class="setClassName(msg.level)">{{msg.time}} [{{msg.component}}]: {{msg.message}}</h6>
+          <h6 v-if="msg.level !== 'attention' " class= "mb-0" :class="setClassName(msg.level)">{{msg.time}} [{{msg.component}}]: {{msg.message}}</h6>
+          <!-- If Its attention message -->
+          <h6 v-else-if="msg.level === 'attention' " class= "mb-0 text-danger lead" > Attention: {{msg.text}}</h6>
       </div>
     </div>
   </div>
@@ -47,11 +49,13 @@ export default {
       }
 
       this.socket.onmessage = (e) => { 
-        console.log(e);
         let msgObj = JSON.parse(e.data);
-        this.msgArray.push(msgObj);
-        const refLog = document.querySelector('.refbox-log');
-        refLog.scrollTop = refLog.scrollHeight;
+        if (msgObj !== [] && msgObj.level !== 'clips' ) {
+          console.log(e);
+          this.msgArray.push(msgObj);
+          const refLog = document.querySelector('.refbox-log');
+          refLog.scrollTop = refLog.scrollHeight;
+        }
       }
     },
 
@@ -73,7 +77,7 @@ export default {
       } else if (msgLevel === 'error') {
         return 'text-danger'
       } else {
-        return 'text-primary'
+        return 'text-danger'
       }
     }
   }

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="container-fluid  border p-0 refbox-log overflow-auto text-left">
-    <div class="d-flex justify-content-end">
-      <button @click=connect class="btn btn-primary "> Connect </button>
-      <button @click=disconnect class="btn btn-primary  ">
+    <div class="d-flex justify-content-end mt-2">
+      <button @click=connect class="btn btn-primary mr-2"> Connect </button>
+      <button @click=disconnect class="btn btn-primary  mr-2 ">
         DC
       </button>
       <button @click=send class="btn btn-primary ">Send Msg</button>

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -1,11 +1,13 @@
 <template>
-  <div class="container-fluid border p-0 refbox-log overflow-auto text-left">
-    <button @click=connect class="btn btn-primary"> Connect </button>
-    <button @click=disconnect class="btn btn-primary">
-      DC
-    </button>
-    <button @click=send class="btn btn-primary">Send Msg</button>
-
+  <div class="container-fluid  border p-0 refbox-log overflow-auto text-left">
+    <div class="d-flex justify-content-end">
+      <button @click=connect class="btn btn-primary "> Connect </button>
+      <button @click=disconnect class="btn btn-primary  ">
+        DC
+      </button>
+      <button @click=send class="btn btn-primary ">Send Msg</button>
+    </div>
+    
     <div class="mx-3 mt-3">
       <div v-for="(msg,index) in msgArray" :key=index>
         <h6 class= "mb-0" :class="setClassName(msg.level)">{{msg.time}} [{{msg.component}}]: {{msg.message}}</h6>

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="container-fluid border p-0 refbox-log overflow-auto text-left">
-    <button @click=connect> Connect </button>
-    <button @click=disconnect>
+    <button @click=connect class="btn btn-primary"> Connect </button>
+    <button @click=disconnect class="btn btn-primary">
       DC
     </button>
-    <button @click=send>Send Msg</button>
+    <button @click=send class="btn btn-primary">Send Msg</button>
 
     <div class="mx-3 mt-3">
       <div v-for="(msg,index) in msgArray" :key=index>

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -12,7 +12,7 @@
       <div v-for="(msg,index) in msgArray" :key=index>
           <h6 v-if="msg.level !== 'attention' " class= "mb-0" :class="setClassName(msg.level)">{{msg.time}} [{{msg.component}}]: {{msg.message}}</h6>
           <!-- If Its attention message -->
-          <h6 v-else-if="msg.level === 'attention' " class= "mb-0 text-danger lead" > Attention: {{msg.text}}</h6>
+          <h6 v-else-if="msg.level === 'attention' " class= "mb-0 text-danger" > !Attention: {{msg.text}}</h6>
       </div>
     </div>
   </div>

--- a/frontend-client/src/components/BodyRefboxLog.vue
+++ b/frontend-client/src/components/BodyRefboxLog.vue
@@ -1,20 +1,86 @@
 <template>
   <div class="container-fluid border p-0 refbox-log overflow-auto text-left">
-    <div class="m-2">
-      
+    <button @click=connect> Connect </button>
+    <button @click=disconnect>
+      DC
+    </button>
+    <button @click=send>Send Msg</button>
+
+    <div class="mx-3 mt-3">
+      <div v-for="(msg,index) in msgArray" :key=index>
+        <h6 class= "mb-0" :class="setClassName(msg.level)">{{msg.time}} [{{msg.component}}]: {{msg.message}}</h6>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'BodyRefboxLog'
+  name: 'BodyRefboxLog',
+
+  data() {
+    return {
+      msgArray: [],
+      status: 'disconnected',
+      socket: null
+    }
+  },
+
+  mounted() {
+    this.connect();
+  },
+
+  methods: {
+
+    connect() {
+      this.socket = new WebSocket('ws://localhost:1234');
+
+      this.socket.onopen = (e) => {
+        console.log("Connection established", e);
+        this.status = 'connected';
+      }
+
+      this.socket.onclose = (e) => {
+        console.log("Connection debunked", e);
+      }
+
+      this.socket.onmessage = (e) => { 
+        console.log(e);
+        let msgObj = JSON.parse(e.data);
+        this.msgArray.push(msgObj);
+        const refLog = document.querySelector('.refbox-log');
+        refLog.scrollTop = refLog.scrollHeight;
+      }
+    },
+
+    send() {
+      this.socket.send(`{"message": "testuu"}`)
+      console.log('sent!');
+    },
+
+    disconnect() {
+      this.status = 'disconnected';
+      this.socket.close();
+    },
+
+    setClassName(msgLevel) {
+      if (msgLevel === 'info') {
+        return 'text-light'
+      } else if (msgLevel === 'warn' ) {
+        return 'text-danger'
+      } else if (msgLevel === 'error') {
+        return 'text-danger'
+      } else {
+        return 'text-primary'
+      }
+    }
+  }
 }
 </script>
 
 <style >
 .refbox-log {
   min-height: 29vh;
-  max-height: 40vh;
+  max-height: 29vh;
 }
 </style>

--- a/frontend-client/src/components/BodyRobotsTeamCyan.vue
+++ b/frontend-client/src/components/BodyRobotsTeamCyan.vue
@@ -64,7 +64,7 @@ export default {
 
   mounted(){
     this.fetchCyanRobots()
-    // this.pollRobotInfo()
+    this.pollRobotInfo()
   },
 
   methods: {

--- a/frontend-client/src/components/BodyRobotsTeamCyan.vue
+++ b/frontend-client/src/components/BodyRobotsTeamCyan.vue
@@ -64,7 +64,7 @@ export default {
 
   mounted(){
     this.fetchCyanRobots()
-    this.pollRobotInfo()
+    // this.pollRobotInfo()
   },
 
   methods: {

--- a/frontend-client/src/components/BodyScoreTeamA.vue
+++ b/frontend-client/src/components/BodyScoreTeamA.vue
@@ -1,6 +1,6 @@
 <template>
   <div >
-    <h3 v-if="phase !== 'Pre_game'">Points: {{scoreCyan}}</h3>
+    <h4 v-if="phase !== 'Pre_game'">Points: {{scoreCyan}}</h4>
     <div class="awarded-points-container border-top">
       <div class="row m-0 text-left ">
         <div 
@@ -8,7 +8,7 @@
           v-for="(award,index) in awardedPoints" 
           :key='index'>
           <div v-if="award.team === 'CYAN'">
-              <h6 style="font-size: 15px;">
+              <h6 style="font-size: 13px;">
                   {{index + 1}}.
                   [{{formatSeconds(award['game-time'])}}]
                   {{award.phase.substring(0,4)}}

--- a/frontend-client/src/components/ConfirmDeliveryModal.vue
+++ b/frontend-client/src/components/ConfirmDeliveryModal.vue
@@ -98,7 +98,9 @@ export default {
 .modal-title-h6 {
   color: var(--main-cyan-color);
 }
-
+.delivery-infos{
+  color: orangered !important;
+}
 button {
   margin-top: 10px;
   margin-left: 10px;

--- a/frontend-client/src/components/FooterOrdersGenerator.vue
+++ b/frontend-client/src/components/FooterOrdersGenerator.vue
@@ -152,7 +152,7 @@ export default {
   },
   mounted() {
     this.fetchAllOrders();
-    // this.pollAllOrders();
+    this.pollAllOrders();
   },
   methods: {
     ...mapActions(['fetchAllOrders', 'populateProductsArray',]),

--- a/frontend-client/src/components/FooterOrdersGenerator.vue
+++ b/frontend-client/src/components/FooterOrdersGenerator.vue
@@ -9,6 +9,7 @@
         <div class="max-height-81 pb-0 mb-0 d-flex">
           <img :src="require(`@/assets/products/generated/${getProductsImg(order.id)}`)" 
                class="max-height-81 max-width-65 img-fluid" 
+               :class="activeDeliveryPeriodImage(order['delivery-period'])"
           > 
           <!-- c0_black__black.svg -->
         </div>  
@@ -184,10 +185,22 @@ export default {
     // Grays out orders that are not active
     activeDeliveryPeriod(deliveryPeriod){
       // Check if it is in the delivery period
-      if (deliveryPeriod[0] <= this.gametime && deliveryPeriod[1] >= this.gametime) {
+      if (deliveryPeriod[0] <= parseInt(this.gametime) && deliveryPeriod[1] >= parseInt(this.gametime)) {
         return 'text-active'
       } else {
         return 'text-dark'
+      }
+    },
+    activeDeliveryPeriodImage(deliveryPeriod){
+      // Check if it is in the delivery period
+      if (deliveryPeriod[0] <= parseInt(this.gametime) && deliveryPeriod[1] >= parseInt(this.gametime)) {
+        console.log(parseInt(this.gametime));
+        
+        return ''
+      } 
+      // If it's not
+      else {
+        return 'opacity-4'
       }
     },
   }
@@ -239,6 +252,9 @@ export default {
 
 .max-width-65{
   max-width: 65px !important;
+}
+.opacity-4{
+  opacity: .4;
 }
 
 </style>

--- a/frontend-client/src/components/FooterOrdersGenerator.vue
+++ b/frontend-client/src/components/FooterOrdersGenerator.vue
@@ -188,14 +188,12 @@ export default {
       if (deliveryPeriod[0] <= parseInt(this.gametime) && deliveryPeriod[1] >= parseInt(this.gametime)) {
         return 'text-active'
       } else {
-        return 'text-dark'
+        return 'text-muted'
       }
     },
     activeDeliveryPeriodImage(deliveryPeriod){
       // Check if it is in the delivery period
       if (deliveryPeriod[0] <= parseInt(this.gametime) && deliveryPeriod[1] >= parseInt(this.gametime)) {
-        console.log(parseInt(this.gametime));
-        
         return ''
       } 
       // If it's not

--- a/frontend-client/src/components/FooterOrdersGenerator.vue
+++ b/frontend-client/src/components/FooterOrdersGenerator.vue
@@ -152,7 +152,7 @@ export default {
   },
   mounted() {
     this.fetchAllOrders();
-    this.pollAllOrders();
+    // this.pollAllOrders();
   },
   methods: {
     ...mapActions(['fetchAllOrders', 'populateProductsArray',]),

--- a/frontend-client/src/components/HeaderCentralInformation.vue
+++ b/frontend-client/src/components/HeaderCentralInformation.vue
@@ -3,11 +3,11 @@
     <div class="pause-play-time mt-2">
       <div class="radio-pause-play row justify-content-center align-items-center">
         <div class="pause-play-container mr-2">
-          <a class="btn p-0" >
-            <font-awesome-icon :icon="['fas','play-circle']" class="fa-2x" />
+          <a class="btn  p-0" >
+            <font-awesome-icon :icon="['fas','play-circle']" class="fa-2x play-btn" />
           </a>
           <a class="btn p-0"> 
-            <font-awesome-icon :icon="['fas','pause-circle']" class="fa-2x" />
+            <font-awesome-icon :icon="['fas','pause-circle']" class="fa-2x pause-btn " />
           </a>  
         </div>
         <div class="time">
@@ -18,12 +18,12 @@
     </div>
 
     <div class="phase row justify-content-center mt-1">
-      <a class="btn p-0" @click.prevent="setPreviousPhase">
-        <font-awesome-icon :icon="['fas','chevron-left']" class="fa-2x" />
+      <a class="btn  p-0" @click.prevent="setPreviousPhase">
+        <font-awesome-icon :icon="['fas','chevron-left']" class="fa-2x previous-btn" />
       </a>
       <h3 class="marg-bot-0">{{getPhase}}</h3>
-      <a class="btn p-0" @click.prevent="setNextPhase">
-        <font-awesome-icon :icon="['fas','chevron-right']" class="fa-2x" />
+      <a class="btn  p-0" @click.prevent="setNextPhase">
+        <font-awesome-icon :icon="['fas','chevron-right']" class="fa-2x next-btn" />
       </a>
     </div>
   </div>
@@ -53,5 +53,9 @@ export default {
 <style scoped>
 .marg-bot-0 {
   margin-bottom: 0px !important;
+}
+
+.next-btn:hover, .previous-btn:hover, .play-btn:hover, .pause-btn:hover{
+  color: green;
 }
 </style>

--- a/frontend-client/src/components/HeaderCentralInformation.vue
+++ b/frontend-client/src/components/HeaderCentralInformation.vue
@@ -42,7 +42,7 @@ export default {
   },
   mounted() {
     this.fetchGameState();
-    setInterval(this.fetchGameState, 1000);
+    // setInterval(this.fetchGameState, 1000);
   },
   methods: {
     ...mapActions(['setNextPhase', 'setPreviousPhase','fetchGameState' ])

--- a/frontend-client/src/components/HeaderCentralInformation.vue
+++ b/frontend-client/src/components/HeaderCentralInformation.vue
@@ -42,7 +42,7 @@ export default {
   },
   mounted() {
     this.fetchGameState();
-    // setInterval(this.fetchGameState, 1000);
+    setInterval(this.fetchGameState, 1000);
   },
   methods: {
     ...mapActions(['setNextPhase', 'setPreviousPhase','fetchGameState' ])

--- a/frontend-client/src/components/HeaderCentralInformation.vue
+++ b/frontend-client/src/components/HeaderCentralInformation.vue
@@ -12,16 +12,16 @@
         </div>
         <div class="time">
           <!-- <h3>{{formatSeconds(getGametime)}}</h3> -->
-          <h3 class="marg-bot-0">{{formatSeconds(getGametime)}}</h3>
+          <h4 class="marg-bot-0">{{formatSeconds(getGametime)}}</h4>
         </div>
       </div>
     </div>
 
-    <div class="phase row justify-content-center mt-1">
+    <div class="phase row justify-content-center align-items-center mt-1">
       <a class="btn  p-0" @click.prevent="setPreviousPhase">
         <font-awesome-icon :icon="['fas','chevron-left']" class="fa-2x previous-btn" />
       </a>
-      <h3 class="marg-bot-0">{{getPhase}}</h3>
+      <h4 class="marg-bot-0">{{getPhase}}</h4>
       <a class="btn  p-0" @click.prevent="setNextPhase">
         <font-awesome-icon :icon="['fas','chevron-right']" class="fa-2x next-btn" />
       </a>

--- a/frontend-client/src/components/HeaderTeam.vue
+++ b/frontend-client/src/components/HeaderTeam.vue
@@ -28,7 +28,7 @@
       </div>
     </div>
     <div v-if="!showFormCyan" class="cyan-name-container ">
-      <h3 class="cyan-name-header ">{{getCyanName}}</h3>
+      <h4 class="cyan-name-header ">{{getCyanName}}</h4>
     </div>
   </div>
 
@@ -60,7 +60,7 @@
       </div>
     </div>
     <div v-if="!showFormMagenta" class="teamname-header-magenta">
-      <h3 class="magenta-name-header">{{getMagentaName}}</h3>
+      <h4 class="magenta-name-header">{{getMagentaName}}</h4>
     </div>
   </div>
 </template>

--- a/frontend-client/src/components/HeaderTeam.vue
+++ b/frontend-client/src/components/HeaderTeam.vue
@@ -123,7 +123,7 @@ export default {
 }
 
 .btn-magenta-header:hover {
-  box-shadow: 0 12px 10px 0 var(--main-magenta-color) ,0 17px 50px 0 rgba(0,0,0,0.80) !important;
+  box-shadow: 0 3px 12px 0 var(--main-magenta-color) ,0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .btn-cyan-header {
@@ -133,7 +133,7 @@ export default {
 }
 
 .btn-cyan-header:hover {
-  box-shadow: 0 12px 10px 0 var(--main-cyan-color),0 17px 50px 0 rgba(0,0,0,0.80) !important;
+  box-shadow: 0 3px 12px 0 var(--main-cyan-color),0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .cyan-name-header  {

--- a/frontend-client/src/components/HeaderTeam.vue
+++ b/frontend-client/src/components/HeaderTeam.vue
@@ -119,21 +119,21 @@ export default {
 .btn-magenta-header {
   color: var(--main-magenta-color) !important;
   border-color: var(--main-magenta-color) !important;
-  transition-duration: 0.4s !important
+  transition-duration: 0.2s !important
 }
 
 .btn-magenta-header:hover {
-  box-shadow: 0 12px 16px 0 var(--main-magenta-color) ,0 17px 50px 0 rgba(0,0,0,0.80) !important;
+  box-shadow: 0 12px 10px 0 var(--main-magenta-color) ,0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .btn-cyan-header {
   color:  var(--main-cyan-color) !important;
   border-color: var(--main-cyan-color) !important;
-  transition-duration: 0.4s !important
+  transition-duration: 0.2s !important
 }
 
 .btn-cyan-header:hover {
-  box-shadow: 0 12px 16px 0 var(--main-cyan-color),0 17px 50px 0 rgba(0,0,0,0.80) !important;
+  box-shadow: 0 12px 10px 0 var(--main-cyan-color),0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .cyan-name-header  {

--- a/frontend-client/src/components/HeaderTeam.vue
+++ b/frontend-client/src/components/HeaderTeam.vue
@@ -123,7 +123,7 @@ export default {
 }
 
 .btn-magenta-header:hover {
-  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.80) !important;
+  box-shadow: 0 12px 16px 0 var(--main-magenta-color) ,0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .btn-cyan-header {
@@ -133,7 +133,7 @@ export default {
 }
 
 .btn-cyan-header:hover {
-  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.80) !important;
+  box-shadow: 0 12px 16px 0 var(--main-cyan-color),0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .cyan-name-header  {

--- a/frontend-client/src/components/HeaderTeam.vue
+++ b/frontend-client/src/components/HeaderTeam.vue
@@ -123,7 +123,7 @@ export default {
 }
 
 .btn-magenta-header:hover {
-  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.19) !important;
+  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .btn-cyan-header {
@@ -133,7 +133,7 @@ export default {
 }
 
 .btn-cyan-header:hover {
-  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.19) !important;
+  box-shadow: 0 12px 16px 0 rgba(0,0,0,0.24),0 17px 50px 0 rgba(0,0,0,0.80) !important;
 }
 
 .cyan-name-header  {

--- a/frontend-client/src/main.js
+++ b/frontend-client/src/main.js
@@ -7,7 +7,7 @@ import { faPlayCircle, faPauseCircle, faChevronLeft, faChevronRight } from '@for
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 
 // Bootswatch import
-import "bootswatch/dist/superhero/bootstrap.min.css"; 
+import "bootswatch/dist/darkly/bootstrap.min.css"; 
 
 
 // Import Vuex Store to have global access in every Component


### PR DESCRIPTION
This PR fixes #4, #5 

### It adds following:

- All  active GUI elements  are visually recognizable on hover.
-  The background is now dark and the contrast correspondingly adjusted.
- Attention messages are also being logged.
- Orders, whose delivery time is active are being displayed active, whereas inactive orders are being grayed out. 
- Box-shadow of the button (Add Team - ) changed to the color of the corresponding team.
 