### PR TITLE
Team menu for Cyan with listed teams and fixed order count to allow fewer/more than 9 orders.

### DIFF
--- a/frontend-client/src/App.vue
+++ b/frontend-client/src/App.vue
@@ -25,6 +25,9 @@ export default {
     ...mapState(['showPhaseSubmenus']),
     phaseSubmenus () {
       return this.$store.getters.getPhaseSubmenusStatus
+    },
+    teamMenuCyan () {
+      return this.$store.getters.getTeamMenuCyanTriggerStatus
     }
   },
   watch: {
@@ -34,14 +37,29 @@ export default {
       } else {
         this.$el.removeEventListener('click', this.closeSubmenusForPhases)
       }
+    },
+    teamMenuCyan() {
+      if (this.$store.getters.getTeamMenuCyanTriggerStatus === true) {
+        this.$el.addEventListener('click', this.closeTeamMenuCyanMethod)
+      } else {
+        this.$el.removeEventListener('click', this.closeTeamMenuCyanMethod)
+      }
     }
   },
   methods: {
-    ...mapActions(['closePhaseSubmenus']),
+    ...mapActions(['closePhaseSubmenus', 'closeTeamMenuCyan']),
     closeSubmenusForPhases(e) {
       // check if anything other than the phase is clicked and close the submenu 
       if (!(e.target.classList.contains('current-phase-anchor')) ) {
         this.closePhaseSubmenus()
+      }
+    },
+    closeTeamMenuCyanMethod(e) {
+      // check if anything other than the menu is clicked and close the submenu
+      console.log();
+      
+      if (!(e.target.classList.contains('cyanSelectArrow')) || (e.target.classList.contains('btn-cyan-header'))) {
+        this.closeTeamMenuCyan()
       }
     }
   }

--- a/frontend-client/src/components/FooterOrdersGenerator.vue
+++ b/frontend-client/src/components/FooterOrdersGenerator.vue
@@ -8,7 +8,7 @@
       <div class="d-flex " >
         <div class="max-height-6rem pb-0 mb-0 d-flex">
           <img 
-              v-if="products.length === 9"
+              v-if="products.length === orderCount"
               :src="require(`@/assets/products/generated/${getProductsImg(order.id)}`)" 
                class="max-height-6rem img-max-width img-fluid" 
                :class="activeDeliveryPeriodImage(order['delivery_period'])"
@@ -178,7 +178,8 @@ export default {
       populated: state => state.orders.populated,
       nameTeamCYAN: state => state.nameTeamCyan,
       gametime: state => state.gametime,
-      nameTeamMAGENTA: state => state.nameTeamMagenta
+      nameTeamMAGENTA: state => state.nameTeamMagenta,
+      orderCount: state => state.orders.orderCount,
     }),
     unconfirmedOrders() {
       console.log(this.allOrders.filter(order => order['unconfirmed_deliveries'].length > 0), 'UNCONIRMED');

--- a/frontend-client/src/components/HeaderTeam.vue
+++ b/frontend-client/src/components/HeaderTeam.vue
@@ -6,24 +6,41 @@
         <div class="col-md-12 my-2 add-team-container">
           <button 
           class="btn  btn-add-team btn-cyan-header"
-          @click="toggleForm()"
-          v-shortkey.once="['f4']" @shortkey="toggleForm()"
+          @click="toggleFormAndTeams()"
+          v-shortkey.once="['f4']" @shortkey="toggleFormAndTeams()"
           >Add Team Cyan</button>
         </div>
         <div class="mb-2" v-show="isClicked">
           <form @submit.prevent="setName(color)"
-                class="form-cyan"
+                class="form-cyan d-flex"
           >
             <input type="text" 
             placeholder="add teamname"
-            class="input-cyan"
+            class="input-cyan "
             required
             ref="cyanInputBox"
             v-model="cyanName"
             >
-            <button type="submit" class="submit-btn">
-               <font-awesome-icon :icon="['fa','arrow-right']" class="fa-1x " />
+            <button type="submit" class="submit-btn" v-show="cyanName.length >= 1">
+               <font-awesome-icon :icon="['fa','arrow-right']" class="fa-1x" 
+                                  
+              />
             </button>
+            <div class="dropdown show">
+              <a class=" btn dropdown-toggle cyanSelectArrow " 
+                 data-toggle="dropdown" href="#" role="button" 
+                 aria-haspopup="true" aria-expanded="false" 
+                 @click.prevent="toggleTeamMenuCyan()">
+              </a>
+              <div class="dropdown-menu cyanDropdown" 
+                   :style="teamMenuTriggeredCyan ? 'display:block' : 'display:none'"
+              >
+                <a href="#" class="dropdown-item" @click.prevent="fillCyanNameInput(knownTeam)"
+                   v-for="(knownTeam,index) in knownTeams" :key="index"  >
+                   {{knownTeam}}
+                </a>
+              </div>
+            </div>
           </form>
         </div>
       </div>
@@ -80,7 +97,7 @@ export default {
   },
   data() {
     return {
-      isClicked: false
+      isClicked: false,
     }
   },
   computed: {
@@ -88,7 +105,9 @@ export default {
       showFormCyan: state => state.showFormCyan,
       showFormMagenta: state => state.showFormMagenta,
       getCyanName: state => state.nameTeamCyan,
-      getMagentaName: state => state.nameTeamMagenta
+      getMagentaName: state => state.nameTeamMagenta,
+      knownTeams: state => state.knownTeams,
+      teamMenuTriggeredCyan: state => state.teamMenuTriggeredCyan
     }),
     cyanName: {
       get() {
@@ -108,7 +127,7 @@ export default {
     }
   },
   methods: {
-    ...mapActions(['setNameCyan', 'setNameMagenta', 'SOCKET_SEND']),
+    ...mapActions(['setNameCyan', 'setNameMagenta', 'SOCKET_SEND', 'toggleTeamMenuCyan', 'openTeamMenuCyan']),
     setName(color) {
       color = color.toUpperCase()
       const msg = {
@@ -130,7 +149,18 @@ export default {
           this.$refs.magentaInputBox.focus()
         })
       }
+    },
+    toggleFormAndTeams(){
+      this.toggleForm()
+      this.openTeamMenuCyan()
+    },
+    fillCyanNameInput(name){
+      this.cyanName = name
+      this.$nextTick(function () {
+          this.$refs.cyanInputBox.focus()
+        })
     }
+    
   }
   
 }
@@ -144,6 +174,10 @@ export default {
   color: var(--main-magenta-color) !important;
   border-color: var(--main-magenta-color) !important;
   transition-duration: 0.2s !important
+}
+.cyanSelectArrow{
+  padding: 0 0.4em !important;
+  
 }
 
 .btn-magenta-header:hover {

--- a/frontend-client/src/store/index.js
+++ b/frontend-client/src/store/index.js
@@ -78,7 +78,6 @@ export default new Vuex.Store({
     SOCKET_ONCLOSE({state,commit, dispatch}){
       const onClose = (e) => { 
         console.log(e);
-        console.log('232');
         if (e.code === 1006) {
           alert('There is no Connection!')
           state.isConnected = false
@@ -120,7 +119,6 @@ export default new Vuex.Store({
             dispatch("SetPointsCyan", cyanPoints)
           }
           else if(msgObj.type === 'order-count') {
-            console.log(msgObj);
             dispatch('setOrderCount', msgObj.count)
           }
           // Websocket sends an array of objects with all of the information
@@ -145,9 +143,6 @@ export default new Vuex.Store({
               dispatch("SetPointsCyan", cyanPoints)
             }
             if(msgObj[0].type === 'known-teams') {
-              console.log(msgObj, 'asd');
-              console.log(msgObj[0]["known_teams"]);
-              
               dispatch('setKnownTeams', msgObj[0]["known_teams"])
             }  
           } 

--- a/frontend-client/src/store/index.js
+++ b/frontend-client/src/store/index.js
@@ -113,6 +113,10 @@ export default new Vuex.Store({
             // const magentaPoints = msgObj.filter(point => point.team === 'Magenta')
             dispatch("SetPointsCyan", cyanPoints)
           }
+          else if(msgObj.type === 'order-count') {
+            console.log(msgObj);
+            dispatch('setOrderCount', msgObj.count)
+          }
           // Websocket sends an array of objects with all of the information
           // Check if that"s the case
           else if(typeof msgObj[0] !== 'undefined'){
@@ -127,6 +131,7 @@ export default new Vuex.Store({
             } else if(msgObj[0].type === 'ring-spec'){
               dispatch("SetRingspecs", msgObj)
             } else if(msgObj[0].type === 'order-info') {
+              console.log(msgObj);
               dispatch("SetOrdersAtReconnect", msgObj)
             } else if(msgObj[0].type === 'points') {
               const cyanPoints = msgObj.filter(point => point.team === 'CYAN')

--- a/frontend-client/src/store/index.js
+++ b/frontend-client/src/store/index.js
@@ -42,11 +42,16 @@ export default new Vuex.Store({
     pointsCyanFlag: false,
     showPhaseSubmenus: false,
     addIpAndPort: false,
+    knownTeams: [],
+    teamMenuTriggeredCyan: false
   },
 
   getters: {
     getPhaseSubmenusStatus(state) {
       return state.showPhaseSubmenus
+    },
+    getTeamMenuCyanTriggerStatus(state){
+      return state.teamMenuTriggeredCyan
     }
   },
 
@@ -85,6 +90,7 @@ export default new Vuex.Store({
     SOCKET_ONMESSAGE({commit, dispatch}) {
       const onMessage = (e) => { 
         let msgObj = JSON.parse(e.data);
+        
         if (msgObj !== [] && msgObj.length !== 0 ) {
           // Messages for the Logger are Objects not an Array such as machine 
           // infos at connect
@@ -138,6 +144,12 @@ export default new Vuex.Store({
               // const magentaPoints = msgObj.filter(point => point.team === 'Magenta')
               dispatch("SetPointsCyan", cyanPoints)
             }
+            if(msgObj[0].type === 'known-teams') {
+              console.log(msgObj, 'asd');
+              console.log(msgObj[0]["known_teams"]);
+              
+              dispatch('setKnownTeams', msgObj[0]["known_teams"])
+            }  
           } 
         }          
       }
@@ -261,6 +273,9 @@ export default new Vuex.Store({
       commit('SOCKET_SEND', msg)
       commit('setGamestate', gamestate)
     },
+    setKnownTeams({commit}, teams){
+      commit('setKnownTeams', teams)
+    },
     randomizeField({commit}) {
       const msg = { "command" : "randomize_field"}
       commit('SOCKET_SEND', msg)
@@ -281,6 +296,15 @@ export default new Vuex.Store({
     },
     closePhaseSubmenus({commit}) {
       commit('closePhaseSubmenus')
+    },
+    toggleTeamMenuCyan({commit}){
+      commit('toggleTeamMenuCyan')
+    },
+    closeTeamMenuCyan({commit}){
+      commit('closeTeamMenuCyan')
+    },
+    openTeamMenuCyan({commit}) {
+      commit('openTeamMenuCyan')
     },
     setWebsocketURL({commit}, URL) {
       commit('setWebsocketURL', URL)
@@ -365,6 +389,18 @@ export default new Vuex.Store({
     },
     setWebsocketURL(state, URL) {
       state.websocketURL = URL
+    },
+    setKnownTeams(state, teams) {
+      state.knownTeams = teams
+    },
+    toggleTeamMenuCyan(state){
+      state.teamMenuTriggeredCyan = !state.teamMenuTriggeredCyan
+    },
+    closeTeamMenuCyan(state) {
+      state.teamMenuTriggeredCyan = false
+    },
+    openTeamMenuCyan(state){
+      state.teamMenuTriggeredCyan = true
     }
   }
 })

--- a/frontend-client/src/store/modules/orders.js
+++ b/frontend-client/src/store/modules/orders.js
@@ -3,7 +3,8 @@ export default{
     allOrders: [],
     products: [],
     populated: false,
-    ordersFlag: false
+    ordersFlag: false,
+    orderCount: 9
   },
 
   getters: {
@@ -29,18 +30,22 @@ export default{
       } else {
         state.allOrders.splice(payload.index, 1, payload.payload)
       }
+    },
+    setOrderCount(state, count) {
+      state.orderCount = count;
     }
   },
 
   actions: {
     SetOrdersAtReconnect({commit, dispatch, state}, payload) {
       if(!state.ordersFlag) {        
+        console.log(payload);
         commit("setOrdersArray", payload)
         dispatch("populateProducts")
       }
     },
     setOrderInfos({commit, dispatch, state}, payload) {
-      if (state.allOrders.length < 9) {
+      if (state.allOrders.length < state.orderCount) {
         // check if there is already that order in the 
         // array so it doesn"t duplicate it
         const index = state.allOrders.findIndex(order => order.id === payload.id)
@@ -53,11 +58,16 @@ export default{
           commit("addOrder", {payload, index})
         }
       }
-      if (state.allOrders.length === 9) {
+      if (state.allOrders.length === state.orderCount) {
         dispatch("sortById", state.allOrders)
 
         dispatch("populateProducts")
       }
+    },
+    setOrderCount({commit}, orderCount){
+      console.log(orderCount);
+      
+      commit('setOrderCount', orderCount)
     },
     populateProducts({commit,state, dispatch}) {
       if (state.allOrders && !state.populated) {

--- a/frontend-client/src/store/modules/orders.js
+++ b/frontend-client/src/store/modules/orders.js
@@ -39,7 +39,6 @@ export default{
   actions: {
     SetOrdersAtReconnect({commit, dispatch, state}, payload) {
       if(!state.ordersFlag) {        
-        console.log(payload);
         commit("setOrdersArray", payload)
         dispatch("populateProducts")
       }


### PR DESCRIPTION
This PR fixes #23.

- It adds Dropdown menu for team cyan with the teams array sent via the websocket.
- It  loads specific number of orders corresponding to the fact in the refbox.